### PR TITLE
Use Hyperdrive Stream id directly

### DIFF
--- a/index.js
+++ b/index.js
@@ -286,7 +286,7 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
 
   if (this._stream) {
     var wire = connection
-    connection = this._stream(this.id)
+    connection = this._stream()
     connection.on('handshake', onhandshake)
     pump(wire, connection, wire)
   } else {

--- a/index.js
+++ b/index.js
@@ -319,6 +319,7 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
   function onhandshake (remoteId) {
     if (!remoteId) remoteId = connection.remoteId
     clearTimeout(timeout)
+    if (connection.id) idHex = connection.id.toString('hex')
     remoteIdHex = remoteId.toString('hex')
     if (peer) peer.retries = 0
 

--- a/index.js
+++ b/index.js
@@ -287,6 +287,7 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
   if (this._stream) {
     var wire = connection
     connection = this._stream()
+    if (connection.id) idHex = connection.id.toString('hex')
     connection.on('handshake', onhandshake)
     pump(wire, connection, wire)
   } else {
@@ -319,7 +320,6 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
   function onhandshake (remoteId) {
     if (!remoteId) remoteId = connection.remoteId
     clearTimeout(timeout)
-    if (connection.id) idHex = connection.id.toString('hex')
     remoteIdHex = remoteId.toString('hex')
     if (peer) peer.retries = 0
 

--- a/test.js
+++ b/test.js
@@ -104,3 +104,22 @@ test('socket should get destroyed on a bad peer', function (t) {
     t.end()
   }, 250)
 })
+
+test('swarm should not connect to self', function (t) {
+  var s = swarm({dht: false, utp: false})
+
+  s.on('connection', function (connection, type) {
+    t.false(connection, 'should never get here')
+    s.destroy()
+    t.end()
+  })
+
+  setTimeout(function () {
+    t.equal(s.totalConnections, 0, '0 connections')
+    s.destroy()
+    t.end()
+  }, 250)
+
+  s.join('test')
+})
+


### PR DESCRIPTION
* Get connection id directly and use that to check for self connection
* Adds test to make sure it is not connecting to self

Honestly, still a bit confused about this one. It didn't seem like Hyperdrive was even using the id passed when creating a [stream before](https://github.com/mafintosh/discovery-swarm/compare/master...joehand:stream-id?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcL289). That argument was just ignored. Can we just get the id from the connection after it is made?

Is the new test a sufficient check?