### PR TITLE
Try to get host and port for connections in all cases

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,17 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
   this.totalConnections++
   connection.on('close', onclose)
 
+  if (!info.host === null) {
+    if (connection.remoteAddress) {
+      info.host = connection.remoteHost
+      info.port = connection.remotePort
+    } else if (typeof connection.address === 'function') {
+      var addr = connection.address()
+      info.host = addr.address
+      info.port = addr.port
+    }
+  }
+
   if (this._stream) {
     var wire = connection
     connection = this._stream(info)


### PR DESCRIPTION
This PR populates the info.host and info.port that's given to the `_stream` method, even if there's no peer info given.

@mafintosh per our discussion on IRC, is there a way to get the remote address from the utp connection? I'm using connection.address(), but it looks like that might give the local addr