### PR TITLE
add opts.announce to join

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,11 @@ Create a new swarm. Options include:
 
 For full list of `opts` take a look at [discovery-channel](https://github.com/maxogden/discovery-channel)
 
-#### `sw.join(key)`
+#### `sw.join(key, [opts])`
 
 Join a channel specified by `key` (usually a name, hash or id, must be a **Buffer** or a **string**). After joining will immediately search for peers advertising this key, and re-announce on a timer.
+
+If you pass `opts.announce` as a falsy value you don't announce your port (e.g. you will be in discover-only mode)
 
 #### `sw.leave(key)`
 

--- a/index.js
+++ b/index.js
@@ -109,15 +109,19 @@ Swarm.prototype.__defineGetter__('connected', function () {
   return this.connections.length
 })
 
-Swarm.prototype.join = function (name) {
+Swarm.prototype.join = function (name, opts) {
   name = toBuffer(name)
+  if (!opts) opts = {}
+  if (typeof opts.announce === 'undefined') opts.announce = true
 
   if (!this._listening && !this._adding) this._listenNext()
 
   if (this._adding) {
     this._adding.push(name)
   } else {
-    this._discovery.join(name, this.address().port, {impliedPort: !!this._utp})
+    var port
+    if (opts.announce) port = this.address().port
+    this._discovery.join(name, port, {impliedPort: !!this._utp})
   }
 }
 
@@ -172,7 +176,6 @@ Swarm.prototype._ondiscover = function () {
     if (!this._options.dht || this._options.dht === true) this._options.dht = {}
     this._options.dht.socket = this._utp
   }
-
   this._discovery = discovery(this._options)
   this._discovery.on('peer', onpeer)
   this._discovery.on('whoami', onwhoami)


### PR DESCRIPTION
defaults to true, if falsy does not pass port to `discoverychannel.join`