### PR TITLE
add active connection count

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,9 +62,9 @@ Number of peers we are trying to connect to
 
 Number of peers discovered but not connected to yet
 
-#### `sw.connections`
+#### `sw.activeConnections`
 
-List of active connections to other peers
+List of active connections to other peers. Counted only after data has been transmitted.
 
 #### `sw.on('connection', connection, info)`
 

--- a/README.md
+++ b/README.md
@@ -44,13 +44,11 @@ Create a new swarm. Options include:
 
 For full list of `opts` take a look at [discovery-channel](https://github.com/maxogden/discovery-channel)
 
-#### `sw.join(key, [opts], [cb])`
+#### `sw.join(key, [opts])`
 
 Join a channel specified by `key` (usually a name, hash or id, must be a **Buffer** or a **string**). After joining will immediately search for peers advertising this key, and re-announce on a timer.
 
 If you pass `opts.announce` as a falsy value you don't announce your port (e.g. you will be in discover-only mode)
-
-If you specify cb, it will be called *when the first round* of discovery has completed. But only on the first round.
 
 #### `sw.leave(key)`
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Create a new swarm. Options include:
 
 For full list of `opts` take a look at [discovery-channel](https://github.com/maxogden/discovery-channel)
 
-#### `sw.join(key, [opts])`
+#### `sw.join(key, [opts], [cb])`
 
 Join a channel specified by `key` (usually a name, hash or id, must be a **Buffer** or a **string**). After joining will immediately search for peers advertising this key, and re-announce on a timer.
 
 If you pass `opts.announce` as a falsy value you don't announce your port (e.g. you will be in discover-only mode)
+
+If you specify cb, it will be called *when the first round* of discovery has completed. But only on the first round.
 
 #### `sw.leave(key)`
 

--- a/index.js
+++ b/index.js
@@ -326,7 +326,7 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
     })
     pump(wire, connection, sentData, wire)
   } else {
-    // TODO: count activeConnections for writing peers
+    // TODO: count activeConnections for writing peers when data is successfully sent
     handshake(connection, this.id, onhandshake)
   }
 

--- a/index.js
+++ b/index.js
@@ -386,6 +386,12 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
       if (!connection._isActive) self.activeConnections++
       connection._isActive = true
     })
+    if (!this._stream) {
+      // TODO: add connection count immediately for now.
+      // Ideally only set with data is sent.
+      if (!connection._isActive) self.activeConnections++
+      connection._isActive = true
+    }
     self.emit('connection', connection, info)
   }
 }

--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ Swarm.prototype.__defineGetter__('connected', function () {
   return this.activeConnections
 })
 
-Swarm.prototype.join = function (name, opts, cb) {
+Swarm.prototype.join = function (name, opts) {
   name = toBuffer(name)
   if (!opts) opts = {}
   if (typeof opts.announce === 'undefined') opts.announce = true
@@ -128,7 +128,7 @@ Swarm.prototype.join = function (name, opts, cb) {
   } else {
     var port
     if (opts.announce) port = this.address().port
-    this._discovery.join(name, port, {impliedPort: opts.announce && !!this._utp}, cb)
+    this._discovery.join(name, port, {impliedPort: opts.announce && !!this._utp})
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "discovery-channel": "^5.3.0",
     "length-prefixed-message": "^3.0.3",
     "pump": "^1.0.1",
+    "through2": "^2.0.3",
     "to-buffer": "^1.0.1"
   },
   "optionalDependencies": {

--- a/test.js
+++ b/test.js
@@ -34,8 +34,6 @@ test('two swarms connect and exchange data', function (t) {
 
   a.on('connection', function (connection) {
     connection.write('hello')
-    t.same(a.activeConnections, 0, 'zero active connection before data')
-    t.same(b.activeConnections, 0, 'zero active connection before data')
     connection.on('data', function (data) {
       t.same(a.activeConnections, 1, 'one active connection after data')
       t.same(b.activeConnections, 1, 'one active connection after data')

--- a/test.js
+++ b/test.js
@@ -34,7 +34,11 @@ test('two swarms connect and exchange data', function (t) {
 
   a.on('connection', function (connection) {
     connection.write('hello')
+    t.same(a.activeConnections, 0, 'zero active connection before data')
+    t.same(b.activeConnections, 0, 'zero active connection before data')
     connection.on('data', function (data) {
+      t.same(a.activeConnections, 1, 'one active connection after data')
+      t.same(b.activeConnections, 1, 'one active connection after data')
       a.destroy()
       b.destroy()
       t.same(data, Buffer('hello'))


### PR DESCRIPTION
* Adds `swarm.activeConnections` (which replaces `swarm.connected`)

This is good to merge, with the caveat below on swarms not using `opts.stream`. 

---

The behavior of `swarm.connected` is the same as before if `opts.stream` is not specified (i.e. counts peers regardless of if data has been transferred).

Note: _count active connections for sockets that write data that aren't using `opts.stream`_

Max and I couldn't figure out how to tell when a socket has written data without some complicated stream magic. Right now sockets not using the `opts.stream` will have `activeConnections` be counting any connection, regardless of if data has been sent (same behavior as before).

To get this consistent with the connections using `opts.stream`, we need something on [this line](https://github.com/mafintosh/discovery-swarm/pull/19/files#diff-168726dbe96b3ce427e7fedce31bb0bcR329) that tells us when `connection` has successfully written data to a peer (we have the read side done fine).

