### PR TITLE
All callback to join

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ Create a new swarm. Options include:
 
 For full list of `opts` take a look at [discovery-channel](https://github.com/maxogden/discovery-channel)
 
-#### `sw.join(key, [opts])`
+#### `sw.join(key, [opts], [cb])`
 
 Join a channel specified by `key` (usually a name, hash or id, must be a **Buffer** or a **string**). After joining will immediately search for peers advertising this key, and re-announce on a timer.
 
 If you pass `opts.announce` as a falsy value you don't announce your port (e.g. you will be in discover-only mode)
+
+If you specify cb, it will be called *when the first round* of discovery has completed. But only on the first round.
 
 #### `sw.leave(key)`
 
@@ -62,9 +64,9 @@ Number of peers we are trying to connect to
 
 Number of peers discovered but not connected to yet
 
-#### `sw.connections`
+#### `sw.activeConnections`
 
-List of active connections to other peers
+List of active connections to other peers. Counted only after data has been transmitted.
 
 #### `sw.on('connection', connection, info)`
 

--- a/test.js
+++ b/test.js
@@ -50,6 +50,27 @@ test('two swarms connect and exchange data', function (t) {
   b.join('test')
 })
 
+test('two swarms connect and callback', function (t) {
+  var a = swarm({dht: false, utp: false})
+  var b = swarm({dht: false, utp: false})
+  var pending = 2
+
+  a.join('test', function () {
+    t.pass('connected')
+    if (!--pending) done()
+  })
+  b.join('test', function () {
+    t.pass('connected')
+    if (!--pending) done()
+  })
+
+  function done () {
+    a.destroy()
+    b.destroy()
+    t.end()
+  }
+})
+
 test('connect many and send data', function (t) {
   var runs = 10
   var outer = 0


### PR DESCRIPTION
Pass the callback of `.join` from discovery-channel. Required changing the internal state management of `this._adding`, used to queue `swarm.join()` calls until ready, to queue with `name, opts, cb` instead of just `name`.

All set!