### PR TITLE
fix example displaying no of connections

### DIFF
--- a/example.js
+++ b/example.js
@@ -4,11 +4,15 @@ var ids = [1, 2, 3, 4, 5]
 
 ids.forEach(function (id) {
   var s = swarm({maxConnections: 2})
-
+  s.join('channel')
   s.listen(10000 + id)
-  s.add(Buffer('hello'))
 
   s.on('connection', function (connection, info) {
-    console.log(id, 'connect', info)
+    connection.write('hello')
+
+    connection.on('data', function (data) {
+      console.log('connections length:', s.connections.length)
+      console.log(id, 'connect', info)
+    })
   })
 })


### PR DESCRIPTION
The example is fixed but this illustrates a bug that I'll file for maxConnections since it does not respect the value passed in.