### PR TITLE
add .connect option

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,8 @@ Create a new swarm. Options include:
 ```js
 {
   id: crypto.randomBytes(32), // peer-id for user
-  stream: stream // stream to replicate across peers
+  stream: stream, // stream to replicate across peers
+  connect: fn, // connect local and remote streams yourself
   utp: true, // use utp for discovery
   tcp: true, // use tcp for discovery
   maxConnections: 0, // max number of connections.

--- a/index.js
+++ b/index.js
@@ -326,7 +326,8 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
     connection = this._stream(info)
     if (connection.id) idHex = connection.id.toString('hex')
     connection.on('handshake', onhandshake)
-    pump(wire, connection, wire)
+    if (this._options.connect) this._options.connect(connection, wire)
+    else pump(wire, connection, wire)
   } else {
     handshake(connection, this.id, onhandshake)
   }


### PR DESCRIPTION
this lets you connect streams yourself.

I stumbled upon this while implementing a throttling feature for desktop. Currently I would have to do something like

```js
disc({
  stream: info => {
    // this is the normal throttle logic
    const input = throttle(speed)
    const output = throttle(speed)

    input.pipe(stream).pipe(output)
    const throttled = duplex(input, output)
    stream.on('error', err => throttled.emit('error', err))

    // this is all the extra plumbing you have to do
    stream.on('handshake', err => throttled.emit('error', err))

    throttled.destroy = () => stream.destroy()

    Object.defineProperty(throttled, 'id', { get: () => stream.id })
    Object.defineProperty(throttled, 'remoteId', { get: () => stream.remoteId })

    return throttled
  }
})
```

With this patch, it can be implemented as simple as

```js
disc({
  connect: (local, remote) => {
    pump(local, throttle(speed), remote, throttle(speed), local)
  }
})
```