### PR TITLE
Fix leave() to not crash upon null address

### DIFF
--- a/index.js
+++ b/index.js
@@ -145,7 +145,7 @@ Swarm.prototype.leave = function (name) {
       }
     }
   } else {
-    this._discovery.leave(name, this.address().port)
+    this._discovery.leave(name, this.address() ? this.address().port : 0)
   }
 }
 


### PR DESCRIPTION
`this._tcp.address()` can actually be `null`, see [net's source code](https://github.com/nodejs/node/blob/bb9d788f772eaf3d6f61fcc27ec2788992faf625/lib/net.js#L1492) and I ran into this corner case with a library of mine that uses `discovery-swarm`. Apparently the underlying [`discovery-channel` still knows how to `leave`](https://github.com/maxogden/discovery-channel/blob/11ab9a063a2be2d438fd97db48e03b8edf25f2f4/index.js#L199) the channel in case the port is falsy.