### PR TITLE
Removed dependency on buffer-equals as it has been deprecated.

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,6 @@ var pump = require('pump')
 var events = require('events')
 var util = require('util')
 var net = require('net')
-var equals = require('buffer-equals')
 var toBuffer = require('to-buffer')
 var crypto = require('crypto')
 var lpmessage = require('length-prefixed-message')
@@ -139,7 +138,7 @@ Swarm.prototype.leave = function (name) {
 
   if (this._adding) {
     for (var i = 0; i < this._adding.length; i++) {
-      if (equals(this._adding[i].name, name)) {
+      if (Buffer.equals(this._adding[i].name, name)) {
         this._adding.splice(i, 1)
         return
       }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "A network swarm that uses discovery-channel to find peers",
   "main": "index.js",
   "dependencies": {
-    "buffer-equals": "^1.0.3",
     "connections": "^1.4.2",
     "debug": "^3.1.0",
     "discovery-channel": "^5.5.1",


### PR DESCRIPTION
`buffer-equals` has been deprecated with the reference to use `Buffer.equals` instead. This PR does just that.