### PR TITLE
fix: Buffer.equals is not a function

### DIFF
--- a/index.js
+++ b/index.js
@@ -138,7 +138,7 @@ Swarm.prototype.leave = function (name) {
 
   if (this._adding) {
     for (var i = 0; i < this._adding.length; i++) {
-      if (Buffer.equals(this._adding[i].name, name)) {
+      if (name.equals(this._adding[i].name)) {
         this._adding.splice(i, 1)
         return
       }


### PR DESCRIPTION
Commit cbb0bd73214d899480356042a6291a201757c1e1 removed  `buffer-equals` as a dependency but accidently treated the documented "Just use Buffer#equals" as a static method.