### PR TITLE
Fixes flaky reconnect #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -206,10 +206,15 @@ Swarm.prototype._ondiscover = function () {
       return
     }
     var peerSeen = self._peersSeen[id] || self._peersSeen[longId]
-    if (peerSeen) {
-      self.emit('peer-rejected', peer, { reason: (peerSeen === PEER_BANNED) ? 'banned' : 'duplicate' })
+    var peerConnected = self._peersIds[id] || self._peersIds[longId]
+    if (peerSeen && peerSeen === PEER_BANNED) {
+      self.emit('peer-rejected', peer, { reason: 'banned' })
+      return
+    } else if (peerSeen && peerConnected) {
+      self.emit('peer-rejected', peer, { reason: 'duplicate' })
       return
     }
+
     self._peersSeen[longId] = PEER_SEEN
     self._peersQueued.push(peerify(peer, channel))
     self.emit('peer', peer)

--- a/test.js
+++ b/test.js
@@ -242,7 +242,7 @@ test('peer should be able to reconnect after disconnection', function (t) {
     return s
   }
 
-  function proceedWithDisconnection() {
+  function proceedWithDisconnection () {
     stablePeer.on('connection-closed', function (connection, info) {
       reconnect()
     })
@@ -250,8 +250,8 @@ test('peer should be able to reconnect after disconnection', function (t) {
     disconnectingPeer.leave('test')
   }
 
-  function reconnect() {
-    if(!reconnecting) {
+  function reconnect () {
+    if (!reconnecting) {
       reconnecting = true
 
       failInCaseOfRejection()
@@ -261,7 +261,7 @@ test('peer should be able to reconnect after disconnection', function (t) {
     }
   }
 
-  function failInCaseOfRejection() {
+  function failInCaseOfRejection () {
     stablePeer.on('peer-rejected', function (peerAddress, details) {
       t.fail('Peer should be able to reconnect but is rejected')
       swarms.forEach(function (s) {
@@ -271,7 +271,7 @@ test('peer should be able to reconnect after disconnection', function (t) {
     })
   }
 
-  function successIfAbleToReconnect() {
+  function successIfAbleToReconnect () {
     disconnectingPeer.on('connection', function (connection, info) {
       t.ok(connection, 'got connection')
       swarms.forEach(function (s) {


### PR DESCRIPTION
I think this patch fixes flaky reconnect #6

The problem prevented reconnecting to a peer after it was dropped for some reason. Unless the sync process was killed and restarted.

The root of the problem was that an "already seen" peer was always discarded as "duplicate" without considering that such peer may have been dropped at some point in the past.

These fix adds an extra check that only discards a peer as "duplicate" if and only if it is "already seen" AND ALSO is "currently connected".