### PR TITLE
Add opts.keepExistingConnections

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,8 @@ Create a new swarm. Options include:
   utp: true, // use utp for discovery
   tcp: true, // use tcp for discovery
   maxConnections: 0, // max number of connections.
-  whitelist: [] // array of ip addresses to restrict connections to
+  whitelist: [], // array of ip addresses to restrict connections to
+  keepExistingConnections: false  // by default, prefer tcp by dropping old utp connections
 }
 ```
 

--- a/index.js
+++ b/index.js
@@ -48,6 +48,7 @@ function Swarm (opts) {
   this._tcpConnections = this._tcp && connections(this._tcp)
   this._adding = null
   this._listening = false
+  this._keepExistingConnections = (opts.keepExistingConnections === true)
 
   this._peersIds = {}
   this._peersSeen = {}
@@ -415,6 +416,12 @@ Swarm.prototype._onconnection = function (connection, type, peer) {
     var oldWrap = self._peersIds[remoteIdHex]
     var old = oldWrap && oldWrap.connection
     var oldType = oldWrap && oldWrap.info.type
+
+    if (old && self._keepExistingConnections) {
+      self.emit('redundant-connection', connection, info)
+      connection.destroy()
+      return
+    }
 
     if (old) {
       debug('duplicate connections detected in handshake, dropping one')


### PR DESCRIPTION
This causes discovery-swarm to prefer existing connections when the flag is set, as opposed to the default logic which will destroy a good UTP (or TCP) connection in favor of a new TCP connection.

This change was motivated by the needs of [mapeo-core](https://github.com/digidem/mapeo-core), which relies on the same connection being used for the duration of a sync between two peers. UTP connections getting swapped out for TCP ones mid-sync was causing us a lot of problems. This would also appear in localhost tests, where an e.g. IPv4 connection began and then an IPv6 connection caused the previous one to be dropped.

Implemented as opt-in, so that this module's many downstream packages aren't affected.